### PR TITLE
Add render to allowed hosts

### DIFF
--- a/backend/crowdhype/settings.py
+++ b/backend/crowdhype/settings.py
@@ -41,7 +41,7 @@ else:
 APPEND_SLASH = True
 
 
-ALLOWED_HOSTS = ["localhost", "127.0.0.1", "testserver"]
+ALLOWED_HOSTS = ["crowdhype.onrender.com", "localhost", "127.0.0.1", "testserver"]
 
 CORS_ALLOWED_ORIGINS = [
     "http://127.0.0.1:3000",


### PR DESCRIPTION
This pull request includes an update to the `backend/crowdhype/settings.py` file to allow access from the deployed domain.

* [`backend/crowdhype/settings.py`](diffhunk://#diff-92b1204fea1c7fd96bb4add901b942c9240ece63b82939de3e1b4357b9daaa2cL44-R44): Added "crowdhype.onrender.com" to the `ALLOWED_HOSTS` list to permit access from the deployed domain.