### PR TITLE
Serve static Django files to production

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ coverage.xml
 
 # Node.js
 node_modules/
+
+# Ignore Django collected static files
+staticfiles/

--- a/backend/crowdhype/settings.py
+++ b/backend/crowdhype/settings.py
@@ -156,6 +156,8 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/5.1/howto/static-files/
 
 STATIC_URL = 'static/'
+STATIC_ROOT = BASE_DIR / "staticfiles"
+
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/5.1/ref/settings/#default-auto-field


### PR DESCRIPTION
This pull request includes a small change to the `backend/crowdhype/settings.py` file. The change sets the `STATIC_ROOT` variable to the `staticfiles` directory within the base directory.

* [`backend/crowdhype/settings.py`](diffhunk://#diff-92b1204fea1c7fd96bb4add901b942c9240ece63b82939de3e1b4357b9daaa2cR159-R160): Added `STATIC_ROOT` variable to specify the directory where static files will be collected.