### PR TITLE
Add backend render url to app.config

### DIFF
--- a/frontend/app.config.js
+++ b/frontend/app.config.js
@@ -6,7 +6,7 @@ export default defineConfig({
     port: 3000,
     proxy: {
       '/api': {
-        target: 'http://localhost:8080',
+        target: process.env.VITE_BACKEND_URL || 'http://127.0.0.1:8000',
         changeOrigin: true,
         source: false,
       },


### PR DESCRIPTION
This pull request includes a change to the `frontend/app.config.js` file to improve the configuration of the proxy target URL.

Configuration improvement:

* [`frontend/app.config.js`](diffhunk://#diff-646d5d11f68a7cd7987d758a0b1e18d17242a11457b543e8772a677831c5e45eL9-R9): Updated the proxy target URL to use the environment variable `VITE_BACKEND_URL` if available, otherwise default to `http://127.0.0.1:8000`.