### PR TITLE
Fix Vinxi SSR entry file path

### DIFF
--- a/frontend/app.config.js
+++ b/frontend/app.config.js
@@ -17,11 +17,13 @@ export default defineConfig({
       '~': '/src',
     },
   },
-  ssr: false,
+  ssr: {
+    entry: "./src/entry-server.jsx",
+  },
   build: {
     rollupOptions: {
       input: {
-        ssr: "src/entry-server.jsx", // ✅ Ensure it's pointing to JSX
+        ssr: "src/entry-server.jsx",
       },
     },
   },


### PR DESCRIPTION
This pull request includes a significant change to the server-side rendering (SSR) configuration in the `frontend/app.config.js` file. The most important change involves modifying the SSR setup to use a new entry point.

Changes to server-side rendering configuration:

* [`frontend/app.config.js`](diffhunk://#diff-646d5d11f68a7cd7987d758a0b1e18d17242a11457b543e8772a677831c5e45eL20-R26): Changed the `ssr` property from a boolean to an object, specifying a new entry point for SSR with `"./src/entry-server.jsx"`.