### PR TITLE
Force solid to recognize App.jsx

### DIFF
--- a/frontend/app.config.js
+++ b/frontend/app.config.js
@@ -14,7 +14,8 @@ export default defineConfig({
   },
   resolve: {
     alias: {
-      '~': '/src',
+      "~": "/src",
+      "src/app": "/src/App.jsx",
     },
   },
   ssr: true,


### PR DESCRIPTION
This pull request includes a small change to the `frontend/app.config.js` file. The change adds an alias for `src/app` to point to `/src/App.jsx`.

* [`frontend/app.config.js`](diffhunk://#diff-646d5d11f68a7cd7987d758a0b1e18d17242a11457b543e8772a677831c5e45eL17-R18): Added an alias for `src/app` to point to `/src/App.jsx`.