### PR TITLE
Add static files to storages in settings

### DIFF
--- a/backend/crowdhype/settings.py
+++ b/backend/crowdhype/settings.py
@@ -36,6 +36,9 @@ STORAGES = {
     "default": {
         "BACKEND": "storages.backends.s3boto3.S3Boto3Storage",
     },
+    "staticfiles": {
+        "BACKEND": "storages.backends.s3boto3.S3Boto3Storage",
+    },
 }
 
 # Quick-start development settings - unsuitable for production


### PR DESCRIPTION
This pull request includes a change to the `backend/crowdhype/settings.py` file to add a new storage backend configuration for static files.

Configuration changes:

* [`backend/crowdhype/settings.py`](diffhunk://#diff-92b1204fea1c7fd96bb4add901b942c9240ece63b82939de3e1b4357b9daaa2cR39-R41): Added a new storage backend configuration for static files using `storages.backends.s3boto3.S3Boto3Storage`.