### PR TITLE
Add a PORT variable to the settings and change the static folder

### DIFF
--- a/backend/crowdhype/settings.py
+++ b/backend/crowdhype/settings.py
@@ -17,6 +17,7 @@ from datetime import timedelta
 import os
 
 BASE_DIR = Path(__file__).resolve().parent.parent
+PORT = env("PORT", "10000")
 
 env = Env()
 env.read_env(os.path.join(BASE_DIR, "crowdhype", ".env"))
@@ -36,8 +37,8 @@ STORAGES = {
     "default": {
         "BACKEND": "storages.backends.s3boto3.S3Boto3Storage",
     },
-    "staticfiles": {
-        "BACKEND": "storages.backends.s3boto3.S3Boto3Storage",
+     "staticfiles": {
+        "BACKEND": "whitenoise.storage.CompressedManifestStaticFilesStorage",
     },
 }
 


### PR DESCRIPTION
This pull request includes changes to the `backend/crowdhype/settings.py` file to update configuration settings. The most important changes include introducing a new environment variable for the port and changing the backend for static files storage.

Configuration updates:

* Added a new environment variable `PORT` with a default value of `10000` to the settings.
* Changed the backend for static files storage from `storages.backends.s3boto3.S3Boto3Storage` to `whitenoise.storage.CompressedManifestStaticFilesStorage`.