### PR TITLE
Add a PORT variable to the settings and change the static folder

### DIFF
--- a/backend/crowdhype/settings.py
+++ b/backend/crowdhype/settings.py
@@ -17,11 +17,11 @@ from datetime import timedelta
 import os
 
 BASE_DIR = Path(__file__).resolve().parent.parent
-PORT = env("PORT", "10000")
 
 env = Env()
 env.read_env(os.path.join(BASE_DIR, "crowdhype", ".env"))
 ENVIRONMENT = env('ENVIRONMENT', default='production')
+PORT = env("PORT", "10000")
 
 # Cloudflare R2 Configuration
 AWS_ACCESS_KEY_ID = env("R2_ACCESS_KEY_ID")


### PR DESCRIPTION
This pull request includes a small change to the `backend/crowdhype/settings.py` file. The change reorders the initialization of the `PORT` variable to occur after the environment variables are read from the `.env` file.

* [`backend/crowdhype/settings.py`](diffhunk://#diff-92b1204fea1c7fd96bb4add901b942c9240ece63b82939de3e1b4357b9daaa2cL20-R24): Moved the initialization of the `PORT` variable to ensure it reads the value from the environment file correctly.