### PR TITLE
Add a PORT variable to the settings and change the static folder

### DIFF
--- a/backend/crowdhype/settings.py
+++ b/backend/crowdhype/settings.py
@@ -21,7 +21,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 env = Env()
 env.read_env(os.path.join(BASE_DIR, "crowdhype", ".env"))
 ENVIRONMENT = env('ENVIRONMENT', default='production')
-PORT = env("PORT", "10000")
+PORT = env.int("PORT", default=10000)
 
 # Cloudflare R2 Configuration
 AWS_ACCESS_KEY_ID = env("R2_ACCESS_KEY_ID")


### PR DESCRIPTION
This pull request includes a change to the `backend/crowdhype/settings.py` file to ensure that the `PORT` environment variable is correctly interpreted as an integer.

* [`backend/crowdhype/settings.py`](diffhunk://#diff-92b1204fea1c7fd96bb4add901b942c9240ece63b82939de3e1b4357b9daaa2cL24-R24): Modified the `PORT` environment variable to be read as an integer instead of a string.