### PR TITLE
Make postgres_locally default to false

### DIFF
--- a/backend/crowdhype/settings.py
+++ b/backend/crowdhype/settings.py
@@ -142,7 +142,7 @@ WSGI_APPLICATION = 'crowdhype.wsgi.application'
 # Database
 # https://docs.djangoproject.com/en/5.1/ref/settings/#databases
 
-POSTGRES_LOCALLY = env.bool('POSTGRES_LOCALLY', default=True)
+POSTGRES_LOCALLY = env.bool('POSTGRES_LOCALLY', default=False)
 
 if POSTGRES_LOCALLY:
     DATABASES = {


### PR DESCRIPTION
This pull request includes a small but significant change to the `backend/crowdhype/settings.py` file. The change modifies the default value of the `POSTGRES_LOCALLY` setting from `True` to `False`.

* [`backend/crowdhype/settings.py`](diffhunk://#diff-92b1204fea1c7fd96bb4add901b942c9240ece63b82939de3e1b4357b9daaa2cL145-R145): Changed the default value of `POSTGRES_LOCALLY` from `True` to `False`.