### PR TITLE
Initialize databases

### DIFF
--- a/backend/crowdhype/settings.py
+++ b/backend/crowdhype/settings.py
@@ -144,6 +144,8 @@ WSGI_APPLICATION = 'crowdhype.wsgi.application'
 
 POSTGRES_LOCALLY = env.bool('POSTGRES_LOCALLY', default=False)
 
+DATABASES = {}
+
 if POSTGRES_LOCALLY:
     DATABASES = {
         'default': {


### PR DESCRIPTION
This pull request includes a small change to the `backend/crowdhype/settings.py` file. The change initializes the `DATABASES` dictionary before its conditional assignment based on the `POSTGRES_LOCALLY` environment variable.

* [`backend/crowdhype/settings.py`](diffhunk://#diff-92b1204fea1c7fd96bb4add901b942c9240ece63b82939de3e1b4357b9daaa2cR147-R148): Initialized the `DATABASES` dictionary to an empty dictionary before conditionally assigning its value.