### PR TITLE
Add some more environment variable for bucket custon url and media url

### DIFF
--- a/backend/crowdhype/settings.py
+++ b/backend/crowdhype/settings.py
@@ -28,6 +28,7 @@ AWS_ACCESS_KEY_ID = env("R2_ACCESS_KEY_ID")
 AWS_SECRET_ACCESS_KEY = env("R2_SECRET_ACCESS_KEY")
 AWS_STORAGE_BUCKET_NAME = "crowdhype-videos"
 AWS_S3_ENDPOINT_URL = "https://a29df9fc6efa87044ab737dc7167a69f.r2.cloudflarestorage.com"
+AWS_S3_CUSTOM_DOMAIN = "https://pub-9facf8d7f0b64e0f85cdb56585205226.r2.dev"
 AWS_QUERYSTRING_AUTH = False
 
 # Use Cloudflare R2 for media storage
@@ -49,7 +50,8 @@ STORAGES = {
 SECRET_KEY = 'django-insecure-!0yd%egsp83f$0dvcuid)copulkykpl5x9-7s9t$gfnp-qz_#f'
 # SECRET_KEY = env('SECRET_KEY')
 
-MEDIA_URL = '/media/'
+# MEDIA_URL = '/media/'
+MEDIA_URL = f"{AWS_S3_CUSTOM_DOMAIN}/"
 MEDIA_ROOT = BASE_DIR / 'media'
 
 # SECURITY WARNING: don't run with debug turned on in production!


### PR DESCRIPTION
This pull request includes changes to the `backend/crowdhype/settings.py` file to configure the use of Cloudflare R2 for media storage. The most important changes include adding a custom domain for the AWS S3 endpoint and updating the `MEDIA_URL` setting to use this custom domain.

Configuration updates for Cloudflare R2:

* Added `AWS_S3_CUSTOM_DOMAIN` setting to specify the custom domain for the AWS S3 endpoint.
* Updated the `MEDIA_URL` setting to use the newly added `AWS_S3_CUSTOM_DOMAIN` instead of the default local media URL.