### PR TITLE
Hardcode the media_url

### DIFF
--- a/backend/crowdhype/settings.py
+++ b/backend/crowdhype/settings.py
@@ -51,7 +51,7 @@ SECRET_KEY = 'django-insecure-!0yd%egsp83f$0dvcuid)copulkykpl5x9-7s9t$gfnp-qz_#f
 # SECRET_KEY = env('SECRET_KEY')
 
 # MEDIA_URL = '/media/'
-MEDIA_URL = f"{AWS_S3_CUSTOM_DOMAIN}/"
+MEDIA_URL = 'https://pub-9facf8d7f0b64e0f85cdb56585205226.r2.dev/'
 MEDIA_ROOT = BASE_DIR / 'media'
 
 # SECURITY WARNING: don't run with debug turned on in production!


### PR DESCRIPTION
This pull request includes a change to the `backend/crowdhype/settings.py` file to update the `MEDIA_URL` setting. The change replaces the dynamic AWS S3 custom domain with a fixed URL.

Configuration update:

* [`backend/crowdhype/settings.py`](diffhunk://#diff-92b1204fea1c7fd96bb4add901b942c9240ece63b82939de3e1b4357b9daaa2cL54-R54): Updated `MEDIA_URL` to use a fixed URL instead of the AWS S3 custom domain.