### PR TITLE
Finally fixed some dumb env variables

### DIFF
--- a/backend/crowdhype/settings.py
+++ b/backend/crowdhype/settings.py
@@ -28,7 +28,7 @@ AWS_ACCESS_KEY_ID = env("R2_ACCESS_KEY_ID")
 AWS_SECRET_ACCESS_KEY = env("R2_SECRET_ACCESS_KEY")
 AWS_STORAGE_BUCKET_NAME = "crowdhype-videos"
 AWS_S3_ENDPOINT_URL = "https://a29df9fc6efa87044ab737dc7167a69f.r2.cloudflarestorage.com"
-AWS_S3_CUSTOM_DOMAIN = "https://pub-9facf8d7f0b64e0f85cdb56585205226.r2.dev"
+AWS_S3_CUSTOM_DOMAIN = "pub-9facf8d7f0b64e0f85cdb56585205226.r2.dev"
 AWS_QUERYSTRING_AUTH = False
 
 # Use Cloudflare R2 for media storage
@@ -51,7 +51,7 @@ SECRET_KEY = 'django-insecure-!0yd%egsp83f$0dvcuid)copulkykpl5x9-7s9t$gfnp-qz_#f
 # SECRET_KEY = env('SECRET_KEY')
 
 # MEDIA_URL = '/media/'
-MEDIA_URL = 'https://pub-9facf8d7f0b64e0f85cdb56585205226.r2.dev/'
+MEDIA_URL = f"https://{AWS_S3_CUSTOM_DOMAIN}/"
 MEDIA_ROOT = BASE_DIR / 'media'
 
 # SECURITY WARNING: don't run with debug turned on in production!


### PR DESCRIPTION
This pull request includes changes to the `backend/crowdhype/settings.py` file to update the configuration of AWS S3 and media URLs. The most important changes include modifying the `AWS_S3_CUSTOM_DOMAIN` and updating the `MEDIA_URL` to use the custom domain.

Changes to AWS S3 and media URLs:

* [`backend/crowdhype/settings.py`](diffhunk://#diff-92b1204fea1c7fd96bb4add901b942c9240ece63b82939de3e1b4357b9daaa2cL31-R31): Changed `AWS_S3_CUSTOM_DOMAIN` to remove the protocol from the domain string.
* [`backend/crowdhype/settings.py`](diffhunk://#diff-92b1204fea1c7fd96bb4add901b942c9240ece63b82939de3e1b4357b9daaa2cL54-R54): Updated `MEDIA_URL` to use the `AWS_S3_CUSTOM_DOMAIN` dynamically.